### PR TITLE
fixes #84 (move check for base class into separate method)

### DIFF
--- a/lib/Test/Class/Moose/Role/Executor.pm
+++ b/lib/Test/Class/Moose/Role/Executor.pm
@@ -42,19 +42,7 @@ sub runtests {
     $report->_start_benchmark;
     my @test_classes = $self->test_classes;
 
-    my @bad = grep { !$_->isa('Test::Class::Moose') } @test_classes;
-    if (@bad) {
-        my $msg = 'Found the following class';
-        $msg .= 'es' if @bad > 1;
-        $msg
-          .= ' that '
-          . ( @bad > 1 ? 'are'        : 'is' ) . ' not '
-          . ( @bad > 1 ? 'subclasses' : 'a subclass' )
-          . " of Test::Class::Moose: @bad";
-        $msg .= ' (did you load '
-          . ( @bad > 1 ? 'these classes' : 'this class' ) . '?)';
-        die $msg;
-    }
+    $self->_validate_test_classes(@test_classes);
 
     context_do {
         my $ctx = shift;
@@ -75,6 +63,24 @@ END
 
     $report->_end_benchmark;
     return $self;
+}
+
+sub _validate_test_classes {
+    my $self = shift;
+
+    my @bad = grep { !$_->isa('Test::Class::Moose') } @_;
+    if (@bad) {
+        my $msg = 'Found the following class';
+        $msg .= 'es' if @bad > 1;
+        $msg
+          .= ' that '
+          . ( @bad > 1 ? 'are'        : 'is' ) . ' not '
+          . ( @bad > 1 ? 'subclasses' : 'a subclass' )
+          . " of Test::Class::Moose: @bad";
+        $msg .= ' (did you load '
+          . ( @bad > 1 ? 'these classes' : 'this class' ) . '?)';
+        die $msg;
+    }
 }
 
 sub _run_test_classes {


### PR DESCRIPTION
A trivial refactoring to help with custom executors that don't want to load all their classes up front.