### PR TITLE
Use "sum0", not "sum"

### DIFF
--- a/lib/Test/Class/Moose/Report.pm
+++ b/lib/Test/Class/Moose/Report.pm
@@ -33,7 +33,7 @@ has test_classes => (
 
 sub num_test_instances {
     my $self = shift;
-    return sum map { $_->num_test_instances } $self->all_test_classes;
+    return sum0 map { $_->num_test_instances } $self->all_test_classes;
 }
 
 sub num_test_methods {


### PR DESCRIPTION
“sum” was not being imported and was resulting in a warning.  Use
“sum0” to be consistent with the code in “num_tests_run”.