### PR TITLE
Improve the extendability of TCM

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,12 @@ Revision history for Perl distribution Test-Class-Moose
     behavior. See the documentation for Test::Class::Moose::Role::Executor for
     methods which you can wrap.
 
+  [BACKWARDS INCOMPATIBILITIES]
+
+  * Removed the never-documented Test::Class::Moose::Report's is_parallel
+    attribute. This was present because in older versions of TCM, reporting
+    was broken when tests were run in parallel.
+
 0.91     2017-12-07
 
   [BUG FIXES]

--- a/Changes
+++ b/Changes
@@ -2,6 +2,14 @@ Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  * Added a new "executor_roles" parameter to the Test::Class::Moose::Runner
+    constructor. This allows you to apply roles to the executor (the object
+    which executes test classes) as a way to extend the default TCM
+    behavior. See the documentation for Test::Class::Moose::Role::Executor for
+    methods which you can wrap.
+
 0.91     2017-12-07
 
   [BUG FIXES]

--- a/lib/Test/Class/Moose/Executor/Parallel.pm
+++ b/lib/Test/Class/Moose/Executor/Parallel.pm
@@ -117,7 +117,7 @@ sub _run_test_classes_in_parallel {
         $subtest->attach($id);
         $subtest->run(
             sub {
-                $class_report = $self->_run_test_class($test_class);
+                $class_report = $self->run_test_class($test_class);
             }
         );
         $subtest->detach;
@@ -159,7 +159,7 @@ sub _build_fork_manager {
     return $pfm;
 }
 
-around _run_test_method => sub {
+around run_test_method => sub {
     my $orig = shift;
     my $self = shift;
 

--- a/lib/Test/Class/Moose/Report.pm
+++ b/lib/Test/Class/Moose/Report.pm
@@ -13,12 +13,6 @@ with 'Test::Class::Moose::Role::HasTimeReport';
 
 use List::Util qw( first sum0 );
 
-has 'is_parallel' => (
-    is      => 'ro',
-    isa     => 'Bool',
-    default => 0,
-);
-
 has test_classes => (
     is      => 'ro',
     traits  => ['Array'],

--- a/lib/Test/Class/Moose/Role/Executor.pm
+++ b/lib/Test/Class/Moose/Role/Executor.pm
@@ -102,16 +102,7 @@ sub _run_test_classes {
     }
 }
 
-sub _build_test_report {
-    my $self = shift;
-
-    # XXX - This isn't very elegant and won't work well in the face of other
-    # types of Executors. However, the real fix is to make parallel reporting
-    # actually work so the report doesn't have to care about this.
-    return Test::Class::Moose::Report->new(
-        is_parallel => $self->is_parallel,,
-    );
-}
+sub _build_test_report { Test::Class::Moose::Report->new }
 
 sub run_test_class {
     my $self       = shift;

--- a/t/basic.t
+++ b/t/basic.t
@@ -64,7 +64,6 @@ subtest_streamed(
 );
 
 my %expect = (
-    is_parallel        => F(),
     num_tests_run      => 27,
     num_test_instances => 2,
     num_test_methods   => 9,

--- a/t/executor_roles.t
+++ b/t/executor_roles.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+use Test::Class::Moose::Runner;
+
+{
+    package My::Role;
+    use Moose::Role;
+}
+
+my $runner = Test::Class::Moose::Runner->new(
+    executor_roles => ['My::Role'],
+);
+
+ok( $runner->_executor->does('My::Role'),
+    'executor roles are applied to executor object'
+);
+
+done_testing();

--- a/t/lib/Test/Reporting.pm
+++ b/t/lib/Test/Reporting.pm
@@ -32,9 +32,7 @@ sub test_report {
         'class reports have expected names'
     );
 
-    for my $method (
-        qw( is_parallel num_tests_run num_test_instances num_test_methods ))
-    {
+    for my $method (qw( num_tests_run num_test_instances num_test_methods )) {
         is( $report->$method,
             $expect->{$method},
             $method

--- a/t/parallel.t
+++ b/t/parallel.t
@@ -86,7 +86,6 @@ for my $class (@classes) {
 }
 
 my %expect = (
-    is_parallel        => T(),
     num_tests_run      => 44,
     num_test_instances => 10,
     num_test_methods   => 22,

--- a/t/parameterized.t
+++ b/t/parameterized.t
@@ -34,7 +34,6 @@ is( intercept { $runner->runtests },
 );
 
 my %expect = (
-    is_parallel        => F(),
     num_tests_run      => 2,
     num_test_instances => 2,
     num_test_methods   => 2,

--- a/t/skip.t
+++ b/t/skip.t
@@ -26,7 +26,6 @@ test_events_is(
 );
 
 my %expect = (
-    is_parallel        => F(),
     num_tests_run      => 2,
     num_test_instances => 2,
     num_test_methods   => 2,

--- a/t/test_class_is_not_loaded.t
+++ b/t/test_class_is_not_loaded.t
@@ -9,7 +9,7 @@ like(
     dies {
         Test::Class::Moose::Runner->new(
             test_classes => ['Test::Class::Not::Loaded'],
-          )->runtests
+        )->runtests
     },
     qr/\QFound the following class that is not a subclass of Test::Class::Moose: Test::Class::Not::Loaded (did you load this class?)/,
     'got expected error when trying to run a class which is not loaded'
@@ -25,7 +25,7 @@ like(
     dies {
         Test::Class::Moose::Runner->new(
             test_classes => [ 'Test::Class::Not::Loaded', 'Foo' ],
-          )->runtests
+        )->runtests
     },
     qr/\QFound the following classes that are not subclasses of Test::Class::Moose: Test::Class::Not::Loaded Foo (did you load these classes?)/,
     'got expected error when trying to run a class which is not loaded and one which is not a TCM subclass'

--- a/t/test_control_methods_skip.t
+++ b/t/test_control_methods_skip.t
@@ -35,7 +35,6 @@ subtest_streamed(
 );
 
 my %expect = (
-    is_parallel        => F(),
     num_tests_run      => 1,
     num_test_instances => 2,
     num_test_methods   => 1,


### PR DESCRIPTION
This involved the following changes:

* Making some methods in TCM::Role::Executor public and documenting them as
  extension points.

* Added an is_parallel attribute to the Executor role for extensions.

* Adding a new TCM::Runner constructor param, executor_roles, to allow
  arbitrary roles to be applied to the executor.