### PR TITLE
Make tests pass with plain prove

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -227,7 +227,7 @@ subtest_streamed(
                             call subevents => array {
                                 event Exception => sub {
                                     call error => match
-                                      qr{\Qforced die at t\E.\Qbasic.t\E.+}s;
+                                      qr{\Qforced die at \E(\./)?\Qt\E.\Qbasic.t\E.+}s;
                                 };
                                 event Plan => sub {
                                     call max => 0;

--- a/t/basic.t
+++ b/t/basic.t
@@ -227,7 +227,7 @@ subtest_streamed(
                             call subevents => array {
                                 event Exception => sub {
                                     call error => match
-                                      qr{\Qforced die at \E(\./)?\Qt\E.\Qbasic.t\E.+}s;
+                                      qr{\Qforced die at \E.*\Qbasic.t\E.+}s;
                                 };
                                 event Plan => sub {
                                     call max => 0;

--- a/t/test_control_methods.t
+++ b/t/test_control_methods.t
@@ -60,7 +60,7 @@ subtest_streamed(
                         };
                         event Diag => sub {
                             call message => match
-                              qr/\Qforced die at t\E.\Qtest_control_methods.t\E.+/s;
+                              qr/\Qforced die at \E(\.\/)?\Qt\E.\Qtest_control_methods.t\E.+/s;
                         };
                         event Plan => sub {
                             call max => 1;

--- a/t/test_control_methods.t
+++ b/t/test_control_methods.t
@@ -60,7 +60,7 @@ subtest_streamed(
                         };
                         event Diag => sub {
                             call message => match
-                              qr/\Qforced die at \E(\.\/)?\Qt\E.\Qtest_control_methods.t\E.+/s;
+                              qr{\Qforced die at \E.*\Qtest_control_methods.t\E.+}s;
                         };
                         event Plan => sub {
                             call max => 1;


### PR DESCRIPTION
When I run the tests from the repository with `prove -vlbr`, then two tests (`basic.t `and `test_control_methods`) have one failure each.  The failure disappears when I directly call `prove -vlbr t/basic.t`.  Apparently `prove` without a path prepends `./t/`  before the test files: the failure reappears when I call `prove -vlbr ./t/basic.t`.  The patch allows for an optional `./` before the path names in the `die` messages.
`make test` passes with and without the patch.

This PR is a "side effect" of my work with test-class-moose as my July assignment in the CPAN Pull Request Challenge.