### PR TITLE
Bail out if a class extends Test::Class::Moose with a nonexisting/bogus class

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,14 @@ Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
 
+0.93     2018-07-08
+
+  [BUG FIXES]
+
+  * Extending a TCM class with a non-existing or non-TCM class now delivers
+    a fatal error instead of silently ignoring the test class.  PR #93,
+    fixes GH #70.
+
 0.92     2017-12-23
 
   [ENHANCEMENTS]

--- a/t/bad_subclass.t
+++ b/t/bad_subclass.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+use lib 't/lib', 't/badlib';
+
+use Test2::V0;
+
+# This test verifies the error handling when a TCM class extends a
+# non-TCM subclass. All this happens at compile time, so the usual
+# exception testing is not applicable. The modules get a directory of
+# their own in t/badlib to make sure that no other tests pick them up
+# with TCM::Load - which would die, because these modules *are*
+# invalid.
+
+my $error;
+
+# Verify that the error isn't triggered for correct subclassing
+eval 'use UseSubclass bare => 1;';
+$error = $@ // q{};
+is( $error, q{}, 'Subclassing works fine' );
+
+# Verify that a class extending a non-test class can't be loaded
+try_load( 'UseBadSubclass', 'NoTestClass' );
+
+# Verify that a class extending many non-test classes can't be loaded
+try_load( 'UseManyBadClasses', 'NoTestClass', 'Carp', 'Exporter', 'Cwd' );
+
+# Verify that a class extending a nonexisting class can't be loaded
+try_load( 'UseMissingSubclass', 'This::Class::Does::Not::Exist' );
+
+sub try_load {
+    my ( $class, @base_classes ) = @_;
+    eval "use $class bare => 1;";
+    my $error        = $@ // q{};
+    my $base_pattern = join( '\b.*?\b', @base_classes );
+    my $n_classes    = scalar @base_classes;
+    like(
+        $error, qr/\b$class\b  # Bogus module
+                   .*?\b$base_pattern\b      # Base classes
+                   .*?\bTest::Class::Moose\b # Required parent
+                   .*?$class/x,    # Bogus module
+        "Error message provides $n_classes base class(es)"
+    );
+}
+
+done_testing;

--- a/t/badlib/NoTestClass.pm
+++ b/t/badlib/NoTestClass.pm
@@ -1,0 +1,8 @@
+package NoTestClass;
+use strict;
+use warnings;
+
+# This is not a Test::Class::Moose class and thus can not be used
+# to extend a Test::Class::Moose class.
+
+1;

--- a/t/badlib/TestClass.pm
+++ b/t/badlib/TestClass.pm
@@ -1,0 +1,9 @@
+package TestClass;
+use strict;
+use warnings;
+
+# This base class is just fine.
+
+use Test::Class::Moose;
+
+1;

--- a/t/badlib/UseBadSubclass.pm
+++ b/t/badlib/UseBadSubclass.pm
@@ -1,0 +1,10 @@
+package UseBadSubclass;
+use strict;
+use warnings;
+
+# Extending a Test class with a non-Test class must die
+
+use lib 't/badlib';
+use Test::Class::Moose extends => 'NoTestClass';
+
+1;

--- a/t/badlib/UseManyBadClasses.pm
+++ b/t/badlib/UseManyBadClasses.pm
@@ -1,0 +1,11 @@
+package UseManyBadClasses;
+use strict;
+use warnings;
+
+# Extending a Test class with a lots of non-Test classes must die
+
+use lib 't/badlib';
+use Test::Class::Moose extends =>
+  [ 'NoTestClass', 'Carp', 'Exporter', 'Cwd' ];
+
+1;

--- a/t/badlib/UseMissingSubclass.pm
+++ b/t/badlib/UseMissingSubclass.pm
@@ -1,0 +1,9 @@
+package UseMissingSubclass;
+use strict;
+use warnings;
+
+# Extending a Test class with a non-existing class must die
+
+use Test::Class::Moose extends => 'This::Class::Does::Not::Exist';
+
+1;

--- a/t/badlib/UseSubclass.pm
+++ b/t/badlib/UseSubclass.pm
@@ -1,0 +1,10 @@
+package UseSubclass;
+use strict;
+use warnings;
+
+# Extending a Test class with a TCM class must work
+
+use lib 't/badlib';
+use Test::Class::Moose extends => 'TestClass';
+
+1;


### PR DESCRIPTION
A module can extend another test module like this:
`use Test::Class::Moose extends => 'My::Other::Test::Module';`
With this patch, loading fails if `My::Other::Test::Module` either does not exist at all, or exists but is not a test module (i.e. does not `use Test::Class::Moose` itself) - instead of silently discarding the test class.
Some tests and a doc update are included.
Closes #70.